### PR TITLE
refactor: redis에 set 할 때 유효기간 설정

### DIFF
--- a/main/python/live/ioteatime/ai_service/outlier/redis_r.py
+++ b/main/python/live/ioteatime/ai_service/outlier/redis_r.py
@@ -14,4 +14,4 @@ db = properties['REDIS']['db']
 r = redis.Redis(host=host, port=port, password=password, db=db)
 
 def set(name, dict):
-    r.set(name, json.dumps(dict))
+    r.set(name, json.dumps(dict), ex=60*60*24)


### PR DESCRIPTION
redis에 저장된 값이 자꾸 비어버리는 이슈 발생
원인은 서버가 내려갔다 올라가서 그런것이라고 추정됨
따라서 키에 유효기간을 둬서 서버가 꺼져도 삭제되지 않도록 수정함