### PR TITLE
refactor: 예측시 main 전력량만 cross validation 하도록 수정

### DIFF
--- a/main/python/live/ioteatime/ai_service/forecast/influx.py
+++ b/main/python/live/ioteatime/ai_service/forecast/influx.py
@@ -32,4 +32,5 @@ def df_org():
 
         yesterday_midnight = datetime.now().replace(hour=16, minute=0, second=0, microsecond=0) - timedelta(days = 1)
         df.loc[i, 'end_time'] = yesterday_midnight.isoformat() + 'Z'
+
     return df

--- a/main/python/live/ioteatime/ai_service/forecast/main.py
+++ b/main/python/live/ioteatime/ai_service/forecast/main.py
@@ -25,52 +25,35 @@ def backup():
     sql.insert(df_init, daily_predict)
 
 def run(param_grid):
+    backup()
+    channel_forecast(param_grid)
+    all_forecast(hourly_predict)
+    all_forecast(daily_predict)
+
+def channel_forecast(param_grid):
     df_org = influx.df_org()
     for i in range (0, len(df_org)):
-        usage_forecast(param_grid, df_org.loc[i])
+        org = df_org.loc[i]
+        channels = electricity.find_channels(org.organization_id)
+        for channel in channels:
+            for i in range(0, len(channel)):
+                channel_id = channel.id.loc[i]
+                place = channel.place.loc[i]
+                channel_name = channel.channel.loc[i]
+
+                query = electricity.get_query(org, '1h', place, channel_name)
+
+                train.forecast(param_grid, org, query, channel_name, channel_id)
 
 
-def usage_forecast(param_grid, org):
-    organization_id = org.organization_id
-    channels = electricity.find_channels(organization_id)
+def all_forecast(table):
+    query = f'SELECT d.organization_id, -1 as channel_id, d.time, SUM(d.kwh) as kwh \
+             FROM `{table}` AS d \
+             INNER JOIN `channels` AS c \
+             ON d.channel_id = c.channel_id \
+             WHERE c.channel_name = \'main\' \
+             GROUP BY d.organization_id, d.time'
 
-    for channel in channels:
-        for idx in range(0, len(channel)):
-            if channel.channel.loc[idx] == 'main':
-                query = electricity.query_kwh_all(org, '1h')
-            else:
-                query = electricity.query_kwh(org, '1h', channel.place.loc[idx], channel.channel.loc[idx])
+    result = sql.query(query)
+    sql.append(result, table)
 
-            df_usage = electricity.get_kwh(org, query)
-            if (df_usage.empty):
-                continue
-
-            df_usage = electricity.format_w(df_usage)
-
-            outlier_value = electricity.find_outlier(df_usage, 'y')
-            df_train = electricity.set_outlier(df_usage, outlier_value)
-
-            if (df_train.y.loc[0] == df_train.y.loc[len(df_train)-1]):
-                df_forecast = train.constant(df_train.y.loc[0])
-                df_forecast['organization_id'] = organization_id
-                df_forecast['channel_id'] = channel.id.loc[idx]
-                sql.append(df_forecast, daily_predict)
-                continue
-
-            model = train.run(org, df_train, param_grid)
-
-            df_daily_forecast = train.daily_forecast(model, 24*30, '1h', outlier_value)
-            df_daily_forecast['organization_id'] = organization_id
-            if (channel.channel.loc[idx] == 'main'):
-                df_daily_forecast['channel_id'] = -1
-            else:
-                df_daily_forecast['channel_id'] = channel.id.loc[idx]
-            sql.append(df_daily_forecast, daily_predict)
-
-            df_hourly_forecast = train.hourly_forecast(model, 24*3, '1h', outlier_value)
-            df_hourly_forecast['organization_id'] = organization_id
-            if (channel.channel.loc[idx] == 'main'):
-                df_hourly_forecast['channel_id'] = -1
-            else:
-                df_hourly_forecast['channel_id'] = channel.id.loc[idx]
-            sql.append(df_hourly_forecast, hourly_predict)

--- a/main/python/live/ioteatime/ai_service/forecast/sql.py
+++ b/main/python/live/ioteatime/ai_service/forecast/sql.py
@@ -38,6 +38,11 @@ def append(df, table):
             index=False
         )
 
+def save(df, table, organization_id, channel_id):
+    df['organization_id'] = organization_id
+    df['channel_id'] = channel_id
+    append(df, table)
+
 def backup(from_t, to_t):
     try:
         query_str = f"select * from {from_t}"


### PR DESCRIPTION
1. 예측시 main 전력량만 교차검증 하도록 수정 학습시간이 너무 오래걸리는 문제가 발생하여, 전력량 변화가 많은 main만 교차검증하도록 수정함.
2. main.run 메소드 리펙토링 하나의 예측 메소드를 채널별 전력량 예측과 총 전력량 예측 2가지로 메소드 분리
3. 총 전력량 예측 로직 변경 총 전력량 예측은 예측 테이블에서 main 값을 모두 더해서 구하도록 계산 로직 변경