### PR TITLE
refactor: 이상치가 음수가 나오지 않도록 수정

### DIFF
--- a/main/python/live/ioteatime/ai_service/outlier/main.py
+++ b/main/python/live/ioteatime/ai_service/outlier/main.py
@@ -88,4 +88,7 @@ def find_outlier(df, idx):
     min = q1-1.5*iqr
     max = q3+1.5*iqr
 
+    if min < 0 : min = 0
+    if max < 0 : max = 0
+
     return min, max


### PR DESCRIPTION
전력량이 음수가 나오는 상황은 확실히 이상한 데이터가 맞기 때문에 이상치 범위는 0~최대치가 맞다고 판단함.